### PR TITLE
Add detect_language and cache_duration

### DIFF
--- a/Components (BFML)/Inputs/meya.input_string.yaml
+++ b/Components (BFML)/Inputs/meya.input_string.yaml
@@ -4,3 +4,4 @@
             text: "Your question here"
             output: <YOUR_KEY>
             scope: <SCOPE> # e.g. flow|user|bot
+            detect_language: <BOOLEAN>

--- a/Components (BFML)/Inputs/meya.input_string.yaml.meta.yaml
+++ b/Components (BFML)/Inputs/meya.input_string.yaml.meta.yaml
@@ -9,8 +9,37 @@ docstring: |
     `speech`|Text to speak to the user. This field also accepts SSML markup to customize pronunciation.|*Optional. Defaults to value of `text` property*
     `output`|The key used to store the data for subsequent steps in the flow.|*Optional. Default: `value`*
     `scope`|Where to store the data. One of `flow`, `user`, or `bot`.|*Optional. Default: `flow`*
+    `detect_language`|If checked, will set `flow.language` to the language the input was written in.|*Optional. Default: `false`*
     ### Transitions
     When the user submits their response, the `next` action is triggered. By default, this will trigger the next state. You can alter this by explicitly setting a transition for the `next` action in the `transitions` section.
+    ### Example - Language Detection
+    You can use the `meya.input_string` component to detect a user's language. Create a new flow called `language.yaml` and paste the following code.
+    ```
+    triggers:
+      - type: meya.catchall
+        properties:
+            detect_language: false
+    name: language
+    states:
+        first:
+            component: meya.text
+            properties:
+                text: "Your language is {{ flow.language }}"
+
+        input_state:
+            component: meya.input_string
+            properties:
+                text: "Enter some text"
+                detect_language: true
+                output: value
+                scope: flow
+
+        greeting:
+            component: meya.text
+            properties:
+                text: "Your language is {{ flow.language }}"
+    ```
+    Test it out in the test chat window. Entering `hello` will match the `catchall` trigger and start the flow. The bot will say `Your language is` since it hasn't yet detected your language. Enter `hello` again and the bot will respond `Your language is en`. Clear the messages to start over. This time try entering `bonjour`. The bot will respond `Your language is fr`.
 language: yaml
 tags: []
 expanded: false

--- a/Components (BFML)/NLU/meya.api_ai.yaml.meta.yaml
+++ b/Components (BFML)/NLU/meya.api_ai.yaml.meta.yaml
@@ -8,7 +8,7 @@ docstring: |
     `text`|Text to display to the user. Can include Mustache syntax: `{{ flow.value }}`.|*Required*
     `speech`|Text to speak to the user. This field also accepts SSML markup to customize pronunciation.|*Optional. Defaults to value of `text` property*
     `client_access_token`|The Dialogflow client access token from your Dialogflow agent settings.|*Required*
-    `language`|A two letter language code matching one of the Dialogflow agent's languages. For example, `en` for English.|*Required*
+    `language`|A two letter language code matching one of the Dialogflow agent's languages. For example, `en` for English. If left blank, the bot will auto-detect the user's language and set `flow.language` to the appropriate language code.|*Optional. Default: blank (i.e. auto-detect)*
     `require_match`|If `false`, the flow will return the `no_match` action, which you can use to transition to another state.|*Optional. Default: `true`*
     `min_confidence`|The minimum confidence required to match the entity.|*Optional. Default: `0.67`*
     `latch_up`|If `true`, any confidence value greater than `min_confidence` will be rounded up to `1.0`, thus winning any intent collisions.` Confidence values less than `min_confidence` will be rounded down to `0.0`.|`Optional. Default: `false`*
@@ -32,6 +32,33 @@ docstring: |
     `fulfillment.speech`|The Dialogflow agent's response, if you've provided the app with responses.
     `parameters.simplified`|The query submitted to Dialogflow.
     `source`|The source Dialogflow agent.
+    ### Example - Language Detection
+    Create a Dialogflow agent with both English and French language enabled. Create a `greetings` intent in the agent with English and French training phrases, such as `hello` and `bonjour`.
+    Create a new flow called `language.yaml` and paste the following code.
+    ```
+    triggers:
+        - type: meya.catchall
+    name: language
+    states:
+        first:
+            component: meya.text
+            properties:
+                text: "Your language is {{ flow.language }}"
+
+        api_ai_state:
+            component: meya.api_ai
+            properties:
+                text: "Enter some text"
+                client_access_token: <YOUR_CLIENT_ACCESS_TOKEN>
+            transitions:
+                greeting: greeting
+
+        greeting:
+            component: meya.text
+            properties:
+                text: "Your language is {{ flow.language }}"
+    ```
+    Test it out in the test chat window. Enter `hello` and the bot will respond `Your language is en`. Enter `bonjour` and the bot will say `Your language is fr`.
 language: yaml
 tags: []
 expanded: false

--- a/Components (BFML)/NLU/meya.api_ai.yaml.meta.yaml
+++ b/Components (BFML)/NLU/meya.api_ai.yaml.meta.yaml
@@ -8,7 +8,7 @@ docstring: |
     `text`|Text to display to the user. Can include Mustache syntax: `{{ flow.value }}`.|*Required*
     `speech`|Text to speak to the user. This field also accepts SSML markup to customize pronunciation.|*Optional. Defaults to value of `text` property*
     `client_access_token`|The Dialogflow client access token from your Dialogflow agent settings.|*Required*
-    `language`|A two letter language code matching one of the Dialogflow agent's languages. For example, `en` for English. If left blank, the bot will auto-detect the user's language and set `flow.language` to the appropriate language code.|*Optional. Default: blank (i.e. auto-detect)*
+    `language`|A two letter language code matching one of the Dialogflow agent's languages. For example, `en` for English. If omitted, the bot will auto-detect the user's language and set `flow.language` to the appropriate language code.|*Optional. Default: blank (i.e. auto-detect)*
     `require_match`|If `false`, the flow will return the `no_match` action, which you can use to transition to another state.|*Optional. Default: `true`*
     `min_confidence`|The minimum confidence required to match the entity.|*Optional. Default: `0.67`*
     `latch_up`|If `true`, any confidence value greater than `min_confidence` will be rounded up to `1.0`, thus winning any intent collisions.` Confidence values less than `min_confidence` will be rounded down to `0.0`.|`Optional. Default: `false`*
@@ -33,9 +33,7 @@ docstring: |
     `parameters.simplified`|The query submitted to Dialogflow.
     `source`|The source Dialogflow agent.
     ### Example - Language Detection
-    You can use the `meya.api_ai` component to detect a user's language.
-    Create a Dialogflow agent with both English and French language enabled. Create a `greetings` intent in the agent with English and French training phrases, such as `hello` and `bonjour`.
-    Create a new flow called `language.yaml` and paste the following code.
+    You can use the `meya.api_ai` component to detect a user's language. Start by creating a Dialogflow agent with both English and French language enabled. Then create a `greetings` intent in the agent with English and French training phrases, such as `hello` and `bonjour`. Finally, create a new flow called `language.yaml` and paste the following code.
     ```
     triggers:
         - type: meya.catchall

--- a/Components (BFML)/NLU/meya.api_ai.yaml.meta.yaml
+++ b/Components (BFML)/NLU/meya.api_ai.yaml.meta.yaml
@@ -33,6 +33,7 @@ docstring: |
     `parameters.simplified`|The query submitted to Dialogflow.
     `source`|The source Dialogflow agent.
     ### Example - Language Detection
+    You can use the `meya.api_ai` component to detect a user's language.
     Create a Dialogflow agent with both English and French language enabled. Create a `greetings` intent in the agent with English and French training phrases, such as `hello` and `bonjour`.
     Create a new flow called `language.yaml` and paste the following code.
     ```
@@ -58,7 +59,7 @@ docstring: |
             properties:
                 text: "Your language is {{ flow.language }}"
     ```
-    Test it out in the test chat window. Enter `hello` and the bot will respond `Your language is en`. Enter `bonjour` and the bot will say `Your language is fr`.
+    Test it out in the test chat window. Entering `hello` will match the `catchall` trigger and start the flow. The bot will say `Your language is` since it hasn't yet detected your language. Enter `hello` again and the bot will respond `Your language is en`. Clear the messages to start over. This time try entering `bonjour`. The bot will respond `Your language is fr`.
 language: yaml
 tags: []
 expanded: false

--- a/Components (BFML)/NLU/meya.api_ai.yaml.meta.yaml
+++ b/Components (BFML)/NLU/meya.api_ai.yaml.meta.yaml
@@ -14,6 +14,7 @@ docstring: |
     `latch_up`|If `true`, any confidence value greater than `min_confidence` will be rounded up to `1.0`, thus winning any intent collisions.` Confidence values less than `min_confidence` will be rounded down to `0.0`.|`Optional. Default: `false`*
     `scope`|Where to store the data. One of `flow`, `user`, or `bot`.|*Optional. Default: `flow`*
     `buttons`|A YAML list of buttons.|*Optional*
+    `cache_duration`|The number of seconds a request is cached. Set to 0 to force a new request. Note that shorter cache durations may increase latency in bot response since more API calls must be made.|*Optional. Default: `60`*
     **The user's intent will be available as `flow.intent`.**
     ### Transitions
     | Transition | Description | Required |

--- a/Components (BFML)/NLU/meya.luis.yaml.meta.yaml
+++ b/Components (BFML)/NLU/meya.luis.yaml.meta.yaml
@@ -15,6 +15,7 @@ docstring: |
     `latch_up`|If `true`, any confidence value greater than `min_confidence` will be rounded up to `1.0`, thus winning any intent collisions.` Confidence values less than `min_confidence` will be rounded down to `0.0`.|`Optional. Default: `false`*
     `scope`|Where to store the data. One of `flow`, `user`, or `bot`.|*Optional. Default: `flow`*
     `buttons`|A YAML list of buttons.|*Optional*
+    `cache_duration`|The number of seconds a request is cached. Set to 0 to force a new request. Note that shorter cache durations may increase latency in bot response since more API calls must be made.|*Optional. Default: `60`*
     **The user's intent will be available as `flow.intent`.**
     ### Transitions
     | Transition | Description | Required |

--- a/Components (BFML)/NLU/meya.wit.yaml.meta.yaml
+++ b/Components (BFML)/NLU/meya.wit.yaml.meta.yaml
@@ -13,6 +13,7 @@ docstring: |
     `latch_up`|If `true`, any confidence value greater than `min_confidence` will be rounded up to `1.0`, thus winning any intent collisions.` Confidence values less than `min_confidence` will be rounded down to `0.0`.|`Optional. Default: `false`*
     `scope`|Where to store the data. One of `flow`, `user`, or `bot`.|*Optional. Default: `flow`*
     `buttons`|A YAML list of buttons.|*Optional*
+    `cache_duration`|The number of seconds a request is cached. Set to 0 to force a new request. Note that shorter cache durations may increase latency in bot response since more API calls must be made.|*Optional. Default: `60`*
     **The user's intent will be available as `flow.intent`.**
     ### Transitions
     | Transition | Description | Required |

--- a/Triggers/meya.api_ai.yaml.meta.yaml
+++ b/Triggers/meya.api_ai.yaml.meta.yaml
@@ -11,6 +11,7 @@ docstring: |
     `intent_regex`|A regular expression to use to match the incoming intent. Used for advanced intent matching. If set, this overrides the `intent` field.|*Optional*
     `min_confidence`|The minimum confidence that will trigger the intent. A value between `0.0` and `1.0`.|*Optional. Default: `0.67`*
     `max_confidence`|The maximum confidence that will trigger the intent. A value between `0.0` and `1.0`.|*Optional. Default: `1.0`*
+    `cache_duration`|The number of seconds a request is cached. Set to `0` to force a new request. Note that shorter cache durations may increase latency in bot response since more API calls must be made.|*Optional. Default: `60`*
     ### Flow scope variables
     The following data are available on the `flow` scope. They can be accessed from a flow using Mustache syntax: `{{ flow.value }}`, or from a Python component using `self.db.flow.get("value")`.
 

--- a/Triggers/meya.api_ai.yaml.meta.yaml
+++ b/Triggers/meya.api_ai.yaml.meta.yaml
@@ -6,7 +6,7 @@ docstring: |
     | Property | Description | Required|
     |    ---   |     ---     |   ---   |
     `client_access_token`|Your Dialogflow agent's client access token.|*Required*
-    `language`|Your Dialogflow agent's 2-letter ISO 639-1 language code.|*Required*
+    `language`|Your Dialogflow agent's 2-letter ISO 639-1 language code. If left blank, the bot will auto-detect the user's language and set `flow.language` to the appropriate language code.|*Optional. Default: `false`*
     `intent`|The name of the intent the user's input must match. If absent, any intent will match.|*Optional*
     `intent_regex`|A regular expression to use to match the incoming intent. Used for advanced intent matching. If set, this overrides the `intent` field.|*Optional*
     `min_confidence`|The minimum confidence that will trigger the intent. A value between `0.0` and `1.0`.|*Optional. Default: `0.67`*
@@ -31,6 +31,22 @@ docstring: |
         "fruit_list": ["apples", "pears", "bananas"]
     }
     ```
+    ### Example - Language Detection
+    Create a Dialogflow agent with both English and French language enabled. Create a `greetings` intent in the agent with English and French training phrases, such as `hello` and `bonjour`.
+    Create a new flow called `language.yaml` and paste the following code.
+    ```
+    triggers:
+    - type: meya.api_ai
+        properties:
+            client_access_token: <YOUR_CLIENT_ACCESS_TOKEN>
+    name: language
+    states:
+        first:
+            component: meya.text
+            properties:
+                text: "Your language is {{ flow.language }}"
+    ```
+    Test it out in the test chat window. Enter `hello` and the bot will respond `Your language is en`. Enter `bonjour` and the bot will say `Your language is fr`.
 language: yaml
 tags: []
 expanded: false

--- a/Triggers/meya.api_ai.yaml.meta.yaml
+++ b/Triggers/meya.api_ai.yaml.meta.yaml
@@ -48,7 +48,7 @@ docstring: |
             properties:
                 text: "Your language is {{ flow.language }}"
     ```
-    Test it out in the test chat window. Entering `hello` will match the `catchall` trigger and start the flow. The bot will say `Your language is` since it hasn't yet detected your language. Enter `hello` again and the bot will respond `Your language is en`. Clear the messages to start over. This time try entering `bonjour`. The bot will respond `Your language is fr`.
+    Test it out in the test chat window. Entering `hello` will match the `api_ai` trigger and start the flow. The bot will say `Your language is en`. Clear the messages to start over. This time try entering `bonjour`. The bot will respond `Your language is fr`.
 language: yaml
 tags: []
 expanded: false

--- a/Triggers/meya.api_ai.yaml.meta.yaml
+++ b/Triggers/meya.api_ai.yaml.meta.yaml
@@ -6,7 +6,7 @@ docstring: |
     | Property | Description | Required|
     |    ---   |     ---     |   ---   |
     `client_access_token`|Your Dialogflow agent's client access token.|*Required*
-    `language`|Your Dialogflow agent's 2-letter ISO 639-1 language code. If left blank, the bot will auto-detect the user's language and set `flow.language` to the appropriate language code.|*Optional. Default: `false`*
+    `language`|Your Dialogflow agent's 2-letter ISO 639-1 language code. If left blank, the bot will auto-detect the user's language and set `flow.language` to the appropriate language code.|*Optional. Default: blank (i.e. auto-detect)*
     `intent`|The name of the intent the user's input must match. If absent, any intent will match.|*Optional*
     `intent_regex`|A regular expression to use to match the incoming intent. Used for advanced intent matching. If set, this overrides the `intent` field.|*Optional*
     `min_confidence`|The minimum confidence that will trigger the intent. A value between `0.0` and `1.0`.|*Optional. Default: `0.67`*
@@ -33,11 +33,12 @@ docstring: |
     }
     ```
     ### Example - Language Detection
+    You can use the `meya.api_ai` trigger to detect a user's language.
     Create a Dialogflow agent with both English and French language enabled. Create a `greetings` intent in the agent with English and French training phrases, such as `hello` and `bonjour`.
     Create a new flow called `language.yaml` and paste the following code.
     ```
     triggers:
-    - type: meya.api_ai
+      - type: meya.api_ai
         properties:
             client_access_token: <YOUR_CLIENT_ACCESS_TOKEN>
     name: language
@@ -47,7 +48,7 @@ docstring: |
             properties:
                 text: "Your language is {{ flow.language }}"
     ```
-    Test it out in the test chat window. Enter `hello` and the bot will respond `Your language is en`. Enter `bonjour` and the bot will say `Your language is fr`.
+    Test it out in the test chat window. Entering `hello` will match the `catchall` trigger and start the flow. The bot will say `Your language is` since it hasn't yet detected your language. Enter `hello` again and the bot will respond `Your language is en`. Clear the messages to start over. This time try entering `bonjour`. The bot will respond `Your language is fr`.
 language: yaml
 tags: []
 expanded: false

--- a/Triggers/meya.api_ai.yaml.meta.yaml
+++ b/Triggers/meya.api_ai.yaml.meta.yaml
@@ -33,9 +33,7 @@ docstring: |
     }
     ```
     ### Example - Language Detection
-    You can use the `meya.api_ai` trigger to detect a user's language.
-    Create a Dialogflow agent with both English and French language enabled. Create a `greetings` intent in the agent with English and French training phrases, such as `hello` and `bonjour`.
-    Create a new flow called `language.yaml` and paste the following code.
+    You can use the `meya.api_ai` trigger to detect a user's language. Start by creating a Dialogflow agent with both English and French language enabled. Then create a `greetings` intent in the agent with English and French training phrases, such as `hello` and `bonjour`. Finally, create a new flow called `language.yaml` and paste the following code.
     ```
     triggers:
       - type: meya.api_ai

--- a/Triggers/meya.catchall.yaml
+++ b/Triggers/meya.catchall.yaml
@@ -1,4 +1,4 @@
 triggers:
   - type: meya.catchall
-  properties:
+    properties:
         detect_language: <BOOLEAN>

--- a/Triggers/meya.catchall.yaml
+++ b/Triggers/meya.catchall.yaml
@@ -1,2 +1,4 @@
 triggers:
   - type: meya.catchall
+  properties:
+        detect_language: <BOOLEAN>

--- a/Triggers/meya.catchall.yaml.meta.yaml
+++ b/Triggers/meya.catchall.yaml.meta.yaml
@@ -5,7 +5,9 @@ docstring: |
 
     Tip: Combine a `catchall` trigger with the `human.transfer` component to have the bot transfer to a human agent when it can't understand the user.
     ### Properties
-    *None.*
+    | Property | Description | Required|
+    |    ---   |     ---     |   ---   |
+    `detect_language`|If checked, will set flow.language to the language the input was written in.|*Optional. Default: `false`*
     ### Flow scope variables
     The `meya.catchall` trigger sets a variable on the `flow` scope. It can be accessed from a flow using Mustache syntax: `{{ flow.value }}`, or from a Python component using `self.db.flow.get("value")`.
 
@@ -13,6 +15,22 @@ docstring: |
     |   ---    |     ---     |
     `value`|The user's original input.
     `_confidence`|The bot's confidence that this trigger is the best match given the user's input.
+    ### Example
+    Create a new flow `language.yaml`. Paste the following code into the flow.
+    ```
+    triggers:
+        - type: meya.catchall
+        properties:
+            detect_language: true
+    name: language
+    states:
+        first:
+            component: meya.text
+            properties:
+                text: "Your language is {{ flow.language }}"
+    ```
+    Enter `hello` and the bot will respond `Your language is en`. If you enter `bonjour` the bot should respond `Your language is fr`.
+    Now set `detect_language` to `false` in the trigger properties. Enter `hello` or `bonjour` and the bot will respond `Your language is` since it didn't detect the language.
 language: yaml
 tags: []
 expanded: false

--- a/Triggers/meya.catchall.yaml.meta.yaml
+++ b/Triggers/meya.catchall.yaml.meta.yaml
@@ -7,7 +7,7 @@ docstring: |
     ### Properties
     | Property | Description | Required|
     |    ---   |     ---     |   ---   |
-    `detect_language`|If checked, will set flow.language to the language the input was written in.|*Optional. Default: `false`*
+    `detect_language`|If checked, will set `flow.language` to the language the input was written in.|*Optional. Default: `false`*
     ### Flow scope variables
     The `meya.catchall` trigger sets a variable on the `flow` scope. It can be accessed from a flow using Mustache syntax: `{{ flow.value }}`, or from a Python component using `self.db.flow.get("value")`.
 

--- a/Triggers/meya.catchall.yaml.meta.yaml
+++ b/Triggers/meya.catchall.yaml.meta.yaml
@@ -16,7 +16,7 @@ docstring: |
     `value`|The user's original input.
     `_confidence`|The bot's confidence that this trigger is the best match given the user's input.
     ### Example
-    Create a new flow `language.yaml`. Paste the following code into the flow.
+    You can use the `meya.catchall` trigger to detect a user's language. Create a new flow `language.yaml`. Paste the following code into the flow.
     ```
     triggers:
         - type: meya.catchall

--- a/Triggers/meya.catchall.yaml.meta.yaml
+++ b/Triggers/meya.catchall.yaml.meta.yaml
@@ -16,7 +16,7 @@ docstring: |
     `value`|The user's original input.
     `_confidence`|The bot's confidence that this trigger is the best match given the user's input.
     ### Example
-    You can use the `meya.catchall` trigger to detect a user's language. Create a new flow `language.yaml`. Paste the following code into the flow.
+    You can use the `meya.catchall` trigger to detect a user's language. Start by creating a new flow `language.yaml`. Paste the following code into the flow.
     ```
     triggers:
         - type: meya.catchall
@@ -30,7 +30,7 @@ docstring: |
                 text: "Your language is {{ flow.language }}"
     ```
     Enter `hello` and the bot will respond `Your language is en`. If you enter `bonjour` the bot should respond `Your language is fr`.
-    Now set `detect_language` to `false` in the trigger properties. Enter `hello` or `bonjour` and the bot will respond `Your language is` since it didn't detect the language.
+    Clear the messages in the test chat window and set `detect_language` to `false` in the trigger properties. Enter `hello` or `bonjour` and the bot will respond `Your language is` since it didn't detect the language.
 language: yaml
 tags: []
 expanded: false

--- a/Triggers/meya.cms_nlu.yaml.meta.yaml
+++ b/Triggers/meya.cms_nlu.yaml.meta.yaml
@@ -2,7 +2,6 @@
 docstring: |
     ## meya.cms_nlu
     Uses a Bot CMS-trained NLU agent to determine the user's intent and trigger the flow if a matching intent is found.
-
     ### Properties
     | Property | Description | Required|
     |    ---   |     ---     |   ---   |
@@ -12,7 +11,7 @@ docstring: |
     `min_confidence`|The minimum confidence required to match the entity.|*Optional. Default: `0.67`*
     `detect_language`|If `true`, `{{ flow.language }}` will be set to the language the NLU agent detected from the user's input.|*Optional. Default: `false`*
     `use_keyword_fallback`|If checked, a keyword-based approach is used if no NLU spaces are provided.|*Optional*
-    
+    `cache_duration`|The number of seconds a request is cached. Set to 0 to force a new request. Note that shorter cache durations may increase latency in bot response since more API calls must be made.|*Optional. Default: `60`*
     ### Flow scope variables
     The following data are available on the `flow` scope. They can be accessed from a flow using Mustache syntax: `{{ flow.value }}`, or from a Python component using `self.db.flow.get("value")`.
 

--- a/Triggers/meya.cms_nlu.yaml.meta.yaml
+++ b/Triggers/meya.cms_nlu.yaml.meta.yaml
@@ -11,7 +11,7 @@ docstring: |
     `min_confidence`|The minimum confidence required to match the entity.|*Optional. Default: `0.67`*
     `detect_language`|If `true`, `{{ flow.language }}` will be set to the language the NLU agent detected from the user's input.|*Optional. Default: `false`*
     `use_keyword_fallback`|If checked, a keyword-based approach is used if no NLU spaces are provided.|*Optional*
-    `cache_duration`|The number of seconds a request is cached. Set to 0 to force a new request. Note that shorter cache durations may increase latency in bot response since more API calls must be made.|*Optional. Default: `60`*
+    `cache_duration`|The number of seconds a request is cached. Set to `0` to force a new request. Note that shorter cache durations may increase latency in bot response since more API calls must be made.|*Optional. Default: `60`*
     ### Flow scope variables
     The following data are available on the `flow` scope. They can be accessed from a flow using Mustache syntax: `{{ flow.value }}`, or from a Python component using `self.db.flow.get("value")`.
 

--- a/Triggers/meya.luis.yaml.meta.yaml
+++ b/Triggers/meya.luis.yaml.meta.yaml
@@ -12,7 +12,7 @@ docstring: |
     `min_confidence`|The minimum confidence that will trigger the intent. A value between `0.0` and `1.0`.|*Optional. Default: `0.67`*
     `max_confidence`|The maximum confidence that will trigger the intent. A value between `0.0` and `1.0`.|*Optional. Default: `1.0`*
     `subdomain`|The Luis.ai subdomain to use.|*Optional. Default: `westus`*
-    `cache_duration`|The number of seconds a request is cached. Set to 0 to force a new request. Note that shorter cache durations may increase latency in bot response since more API calls must be made.|*Optional. Default: `60`*
+    `cache_duration`|The number of seconds a request is cached. Set to `0` to force a new request. Note that shorter cache durations may increase latency in bot response since more API calls must be made.|*Optional. Default: `60`*
     ### Flow scope variables
     The following data are available on the `flow` scope. They can be accessed from a flow using Mustache syntax: `{{ flow.value }}`, or from a Python component using `self.db.flow.get("value")`.
 

--- a/Triggers/meya.luis.yaml.meta.yaml
+++ b/Triggers/meya.luis.yaml.meta.yaml
@@ -12,6 +12,7 @@ docstring: |
     `min_confidence`|The minimum confidence that will trigger the intent. A value between `0.0` and `1.0`.|*Optional. Default: `0.67`*
     `max_confidence`|The maximum confidence that will trigger the intent. A value between `0.0` and `1.0`.|*Optional. Default: `1.0`*
     `subdomain`|The Luis.ai subdomain to use.|*Optional. Default: `westus`*
+    `cache_duration`|The number of seconds a request is cached. Set to 0 to force a new request. Note that shorter cache durations may increase latency in bot response since more API calls must be made.|*Optional. Default: `60`*
     ### Flow scope variables
     The following data are available on the `flow` scope. They can be accessed from a flow using Mustache syntax: `{{ flow.value }}`, or from a Python component using `self.db.flow.get("value")`.
 

--- a/Triggers/meya.wit.yaml.meta.yaml
+++ b/Triggers/meya.wit.yaml.meta.yaml
@@ -10,7 +10,7 @@ docstring: |
     `intent_regex`|A regular expression to use to match the incoming intent. Used for advanced intent matching. If set, this overrides the `intent` field.|*Optional*
     `min_confidence`|The minimum confidence that will trigger the intent. A value between `0.0` and `1.0`.|*Optional. Default: `0.67`*
     `max_confidence`|The maximum confidence that will trigger the intent. A value between `0.0` and `1.0`.|*Optional. Default: `1.0`*
-    `cache_duration`|The number of seconds a request is cached. Set to 0 to force a new request. Note that shorter cache durations may increase latency in bot response since more API calls must be made.|*Optional. Default: `60`*
+    `cache_duration`|The number of seconds a request is cached. Set to `0` to force a new request. Note that shorter cache durations may increase latency in bot response since more API calls must be made.|*Optional. Default: `60`*
     ### NLU data returned from Wit.ai
     The following data are available on the `flow` scope. They can be accessed from a flow using Mustache syntax: `{{ flow.value }}`, or from a Python component using `self.db.flow.get("value")`.
 

--- a/Triggers/meya.wit.yaml.meta.yaml
+++ b/Triggers/meya.wit.yaml.meta.yaml
@@ -10,6 +10,7 @@ docstring: |
     `intent_regex`|A regular expression to use to match the incoming intent. Used for advanced intent matching. If set, this overrides the `intent` field.|*Optional*
     `min_confidence`|The minimum confidence that will trigger the intent. A value between `0.0` and `1.0`.|*Optional. Default: `0.67`*
     `max_confidence`|The maximum confidence that will trigger the intent. A value between `0.0` and `1.0`.|*Optional. Default: `1.0`*
+    `cache_duration`|The number of seconds a request is cached. Set to 0 to force a new request. Note that shorter cache durations may increase latency in bot response since more API calls must be made.|*Optional. Default: `60`*
     ### NLU data returned from Wit.ai
     The following data are available on the `flow` scope. They can be accessed from a flow using Mustache syntax: `{{ flow.value }}`, or from a Python component using `self.db.flow.get("value")`.
 


### PR DESCRIPTION
Added `cache_duration` to all NLU triggers/components, including `cms_nlu`.
Added `detect_language` to `api_ai` trigger/component, `catchall`, and `input_string`.